### PR TITLE
Columns for virtual attributes not selected

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -25,6 +25,7 @@ class SchemaBuilder {
     this.typeCache = {};
     this.filterIndex = 1;
     this.argFactories = [];
+    this._selectFiltering = true;
     this.defaultArgNameMap = {
       "eq": 'Eq',
       "gt": 'Gt',
@@ -66,6 +67,11 @@ class SchemaBuilder {
 
   argFactory(argFactory) {
     this.argFactories.push(argFactory);
+    return this;
+  }
+
+  selectFiltering(enable) {
+    this._selectFiltering = !!enable;
     return this;
   }
 
@@ -330,6 +336,8 @@ class SchemaBuilder {
   }
 
   _filterForSelects(astNode, modelClass) {
+    if(!this._selectFiltering) return null;
+
     const relations = modelClass.getRelations();
     const selects = [];
   

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -242,29 +242,38 @@ describe('integration tests', () => {
       });
     });
 
-    it('`people` field should include all virtual attributes defined in the Person model', () => {
-      return graphql(schema, '{ people { id, firstName, lastName, fullName } }').then(res => {
-        expect(res.data.people).to.eql([{
-          id: 1,
-          firstName: 'Gustav',
-          lastName: 'Schwarzenegger',
-          fullName: 'Gustav Schwarzenegger'
-        }, {
-          id: 2,
-          firstName: 'Michael',
-          lastName: 'Biehn',
-          fullName: 'Michael Biehn'
-        }, {
-          id: 3,
-          firstName: 'Some',
-          lastName: 'Random-Dudette',
-          fullName: 'Some Random-Dudette'
-        }, {
-          id: 4,
-          firstName: 'Arnold',
-          lastName: 'Schwarzenegger',
-          fullName: 'Arnold Schwarzenegger'
-        }]);
+    describe('#selectFiltering', () => {
+      it('should select all columns for use in virtual attributes when selectFiltering is disabled', () => {
+        schema = mainModule
+          .builder()
+          .model(session.models.Person, {listFieldName: 'people'})
+          .model(session.models.Movie)
+          .model(session.models.Review)
+          .selectFiltering(false)
+          .build();
+        return graphql(schema, '{ people { id, firstName, lastName, fullName } }').then(res => {
+          expect(res.data.people).to.eql([{
+            id: 1,
+            firstName: 'Gustav',
+            lastName: 'Schwarzenegger',
+            fullName: 'Gustav Schwarzenegger'
+          }, {
+            id: 2,
+            firstName: 'Michael',
+            lastName: 'Biehn',
+            fullName: 'Michael Biehn'
+          }, {
+            id: 3,
+            firstName: 'Some',
+            lastName: 'Random-Dudette',
+            fullName: 'Some Random-Dudette'
+          }, {
+            id: 4,
+            firstName: 'Arnold',
+            lastName: 'Schwarzenegger',
+            fullName: 'Arnold Schwarzenegger'
+          }]);
+        });
       });
     });
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -242,6 +242,32 @@ describe('integration tests', () => {
       });
     });
 
+    it('`people` field should include all virtual attributes defined in the Person model', () => {
+      return graphql(schema, '{ people { id, firstName, lastName, fullName } }').then(res => {
+        expect(res.data.people).to.eql([{
+          id: 1,
+          firstName: 'Gustav',
+          lastName: 'Schwarzenegger',
+          fullName: 'Gustav Schwarzenegger'
+        }, {
+          id: 2,
+          firstName: 'Michael',
+          lastName: 'Biehn',
+          fullName: 'Michael Biehn'
+        }, {
+          id: 3,
+          firstName: 'Some',
+          lastName: 'Random-Dudette',
+          fullName: 'Some Random-Dudette'
+        }, {
+          id: 4,
+          firstName: 'Arnold',
+          lastName: 'Schwarzenegger',
+          fullName: 'Arnold Schwarzenegger'
+        }]);
+      });
+    });
+
     describe('#argFactory', () => {
 
       it('should register custom filter arguments', () => {

--- a/tests/setup/models/Person.js
+++ b/tests/setup/models/Person.js
@@ -26,6 +26,7 @@ class Person extends Model {
         parentId: {type: ['integer', 'null']},
         firstName: {type: 'string', minLength: 1, maxLength: 255},
         lastName: {type: 'string', minLength: 1, maxLength: 255},
+        fullName: { type: 'string' },
         gender: {type: 'string', enum: _.values(Person.Gender)},
         age: {type: ['number', 'null']},
         addresses: {
@@ -88,6 +89,14 @@ class Person extends Model {
         }
       }
     };
+  }
+
+  static get virtualAttributes() {
+    return ['fullName'];
+  }
+
+  fullName() {
+    return `${this.firstName} ${this.lastName}`;
   }
 }
 


### PR DESCRIPTION
When a model has virtual attributes that depend on columns that aren't being selected the virtual attributes cause the resolver to return `null`. This can be "fixed" by adding `return null` [here](https://github.com/Vincit/objection-graphql/blob/06f921fd37ede59e0a82295addabc806a28622e5/lib/SchemaBuilder.js#L331). Would it be possible to make `_filterForSelects()` optional?