### PR TITLE
Fragments not populated

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -199,7 +199,7 @@ class SchemaBuilder {
       const ast = (data.fieldASTs || data.fieldNodes)[0];
       const eager = this._buildEager(ast, modelClass, data);
       const argFilter = this._filterForArgs(ast, modelClass, data.variableValues);
-      const selectFilter = this._filterForSelects(ast, modelClass);
+      const selectFilter = this._filterForSelects(ast, modelClass, data);
       const builder = modelClass.query(ctx.knex);
 
       if (ctx.onQuery) {
@@ -244,7 +244,7 @@ class SchemaBuilder {
         // `Unsupported let compound assignment`.
         var relExpr = selectionNode.name.value;
 
-        const selectFilter = this._filterForSelects(selectionNode, relation.relatedModelClass);
+        const selectFilter = this._filterForSelects(selectionNode, relation.relatedModelClass, astRoot);
         const filterNames = [];
 
         if (selectFilter) {
@@ -345,19 +345,26 @@ class SchemaBuilder {
     };
   }
 
-  _filterForSelects(astNode, modelClass) {
-    return null;
+  _filterForSelects(astNode, modelClass, astRoot) {
     const relations = modelClass.getRelations();
     const selects = [];
   
-    for (let i = 0, l = astNode.selectionSet.selections.length; i < l; ++i) {
-      const selectionNode = astNode.selectionSet.selections[i];
-      const relation = relations[selectionNode.name.value];
-
-      if (!relation) {
-        selects.push(selectionNode.name.value);
+    /* Recursively add selects from node */
+    const addSelects = (astNode) => {
+      for (let i = 0, l = astNode.selectionSet.selections.length; i < l; ++i) {
+        let selectionNode = astNode.selectionSet.selections[i];
+        if(selectionNode.kind === 'FragmentSpread') {
+          selectionNode = astRoot.fragments[selectionNode.name.value];
+          return addSelects(selectionNode);
+        }
+        const relation = relations[selectionNode.name.value];
+        if (!relation) {
+          selects.push(selectionNode.name.value);
+        }
       }
     }
+
+    addSelects(astNode);
   
     if (selects.length === 0) {
       return null;

--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -197,7 +197,7 @@ class SchemaBuilder {
 
       const modelClass = modelData.modelClass;
       const ast = (data.fieldASTs || data.fieldNodes)[0];
-      const eager = this._buildEager(ast, modelClass);
+      const eager = this._buildEager(ast, modelClass, data);
       const argFilter = this._filterForArgs(ast, modelClass);
       const selectFilter = this._filterForSelects(ast, modelClass);
       const builder = modelClass.query(ctx.knex);
@@ -226,7 +226,7 @@ class SchemaBuilder {
     };
   }
 
-  _buildEager(astNode, modelClass) {
+  _buildEager(astNode, modelClass, astRoot) {
     const filters = {};
     const relations = modelClass.getRelations();
 
@@ -267,7 +267,7 @@ class SchemaBuilder {
           relExpr += '(' + filterNames.join(', ') + ')';
         }
 
-        let subExpr = this._buildEager(selectionNode, relation.relatedModelClass);
+        let subExpr = this._buildEager(selectionNode, relation.relatedModelClass, astRoot);
 
         if (subExpr.expression.length) {
           relExpr += '.' + subExpr.expression;
@@ -279,6 +279,22 @@ class SchemaBuilder {
         }
 
         expression += relExpr;
+        ++numExpressions;
+      } else if(selectionNode.kind === 'FragmentSpread') {
+        const fragmentSelection = astRoot.fragments[selectionNode.name.value];
+        const fragmentExpr = this._buildEager(fragmentSelection, modelClass, astRoot);
+
+        var fragmentExprString = '';
+        if (fragmentExpr.expression.length) {
+          fragmentExprString += fragmentExpr.expression;
+          Object.assign(filters, fragmentExpr.filters);
+        }
+
+        if (expression.length) {
+          expression += ', ';
+        }
+
+        expression += fragmentExprString;
         ++numExpressions;
       }
     }
@@ -328,6 +344,7 @@ class SchemaBuilder {
   }
 
   _filterForSelects(astNode, modelClass) {
+    return null;
     const relations = modelClass.getRelations();
     const selects = [];
   

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -701,4 +701,54 @@ describe('integration tests', () => {
 
   });
 
+  describe('Fragment Queries', () => {
+    let schema;
+
+    before(() => {
+      schema = mainModule
+        .builder()
+        .model(session.models.Person, {listFieldName: 'people'})
+        .model(session.models.Movie)
+        .model(session.models.Review)
+        .build();
+    });
+
+    it('Fragment spreads should be populated', () => {
+      const query = `
+        query PersonQuery {
+          ...PersonQueryFragment
+        }
+        fragment PersonQueryFragment on Query {
+          person(id: 2) {
+            ...PersonFragment
+          }
+        }
+        fragment PersonFragment on Person {
+          id
+          firstName
+          lastName
+          movies {
+            ...MovieFragment
+          }
+        }
+        fragment MovieFragment on Movie {
+          name
+          releaseDate
+        }`;
+      return graphql(schema, query).then(res => {
+        expect(res.data.person).to.eql({
+          id: 2,
+          firstName: 'Michael',
+          lastName: 'Biehn',
+          movies: [
+            {
+              name: 'The terminator',
+              releaseDate: '1984-10-26'
+            }
+          ]
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
GraphQL queries using fragments are not being resolved correctly. For example:

```graphql
query PersonQuery {
    ...PersonQueryFragment
}
fragment PersonQueryFragment on Query {
    person(id: 2) {
    ...PersonFragment
    }
}
fragment PersonFragment on Person {
    id
    firstName
    lastName
    movies {
    ...MovieFragment
    }
}
fragment MovieFragment on Movie {
    name
    releaseDate
}
```

This pull doesn't work unless select filtering is disabled (see #9). An alternative would be some code to similar to [this](https://github.com/SimpleUpdates/objection-graphql/blob/fc376fafa506d217440176bcb92c20ff2c7a5751/lib/SchemaBuilder.js#L357-L372) which I've disabled because I need virtual attributes.