### PR TITLE
Variable queries not resolved

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -197,8 +197,8 @@ class SchemaBuilder {
 
       const modelClass = modelData.modelClass;
       const ast = (data.fieldASTs || data.fieldNodes)[0];
-      const eager = this._buildEager(ast, modelClass);
-      const argFilter = this._filterForArgs(ast, modelClass);
+      const eager = this._buildEager(ast, modelClass, data);
+      const argFilter = this._filterForArgs(ast, modelClass, data.variableValues);
       const selectFilter = this._filterForSelects(ast, modelClass);
       const builder = modelClass.query(ctx.knex);
 
@@ -226,7 +226,7 @@ class SchemaBuilder {
     };
   }
 
-  _buildEager(astNode, modelClass) {
+  _buildEager(astNode, modelClass, astRoot) {
     const filters = {};
     const relations = modelClass.getRelations();
 
@@ -254,7 +254,7 @@ class SchemaBuilder {
         }
 
         if (selectionNode.arguments.length) {
-          const argFilter = this._filterForArgs(selectionNode, relation.relatedModelClass);
+          const argFilter = this._filterForArgs(selectionNode, relation.relatedModelClass, astRoot.variableValues);
 
           if (argFilter) {
             const filterName = 'f' + (this.filterIndex++);
@@ -267,7 +267,7 @@ class SchemaBuilder {
           relExpr += '(' + filterNames.join(', ') + ')';
         }
 
-        let subExpr = this._buildEager(selectionNode, relation.relatedModelClass);
+        let subExpr = this._buildEager(selectionNode, relation.relatedModelClass, astRoot);
 
         if (subExpr.expression.length) {
           relExpr += '.' + subExpr.expression;
@@ -293,7 +293,7 @@ class SchemaBuilder {
     };
   }
 
-  _filterForArgs(astNode, modelClass) {
+  _filterForArgs(astNode, modelClass, variableValues) {
     const args = astNode.arguments;
 
     if (args.length === 0) {
@@ -307,7 +307,9 @@ class SchemaBuilder {
       const arg = args[i];
       let value;
 
-      if (_.has(arg.value, 'value')) {
+      if(arg.value.kind === 'Variable') {
+        value = variableValues[arg.value.name.value];
+      } else if (_.has(arg.value, 'value')) {
         value = arg.value.value;
       } else {
         value = _.map(arg.value.values, 'value')

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -701,4 +701,47 @@ describe('integration tests', () => {
 
   });
 
+  describe('Queries with variables', () => {
+    let schema;
+
+    before(() => {
+      schema = mainModule
+        .builder()
+        .model(session.models.Person, {listFieldName: 'people'})
+        .model(session.models.Movie)
+        .model(session.models.Review)
+        .build();
+    });
+
+    it('Variables in queries should be replaced with values before querying', () => {
+      const query = `
+        query PersonQuery($id: Int, $movie_id: Int) {
+          person(id: $id) {
+            id
+            firstName
+            lastName
+            movies(id: $movie_id) {
+              name
+            }
+          }
+        }`;
+      const variableValues = {
+        id: 4,
+        movie_id: 1
+      };
+      return graphql(schema, query, null, null, variableValues).then(res => {
+        expect(res.data.person).to.eql({
+          id: 4,
+          firstName: 'Arnold',
+          lastName: 'Schwarzenegger',
+          movies: [
+            {
+              name: 'The terminator'
+            }
+          ]
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
When a query uses a variable the value should be replaced before running the query. Example query:

```graphql
query PersonQuery($id: Int, $movie_id: Int) {
    person(id: $id) {
        id
        firstName
        lastName
        movies(id: $movie_id) {
            name
        }
    }
}
```