### PR TITLE
Fix eager expression for fragments with multiple relations

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -204,6 +204,9 @@ class SchemaBuilder {
       const modelClass = modelData.modelClass;
       const ast = (data.fieldASTs || data.fieldNodes)[0];
       const eager = this._buildEager(ast, modelClass, data);
+      if (eager.expression.length) {
+        eager.expression = '[' + eager.expression + ']';
+      }
       const argFilter = this._filterForArgs(ast, modelClass, data.variableValues);
       const selectFilter = this._filterForSelects(ast, modelClass, data);
       const builder = modelClass.query(ctx.knex);
@@ -276,7 +279,7 @@ class SchemaBuilder {
         let subExpr = this._buildEager(selectionNode, relation.relatedModelClass, astRoot);
 
         if (subExpr.expression.length) {
-          relExpr += '.' + subExpr.expression;
+          relExpr += '.[' + subExpr.expression + ']';
           Object.assign(filters, subExpr.filters);
         }
 
@@ -303,10 +306,6 @@ class SchemaBuilder {
         expression += fragmentExprString;
         ++numExpressions;
       }
-    }
-
-    if (numExpressions > 1) {
-      expression = '[' + expression + ']';
     }
 
     return {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -827,6 +827,46 @@ describe('integration tests', () => {
         });
       });
     });
+
+    it('Fragment spreads with multiple relations should be correctly resolved', () => {
+      const query = `
+        query PersonQuery {
+          person(id: 4) {
+            id
+            movies {
+              id
+            }
+            ...PersonFragment
+          }
+        }
+        fragment PersonFragment on Person {
+          movies {
+            id
+          }
+          parent {
+            id
+          }
+        }`;
+      return graphql(schema, query).then(res => {
+        expect(res.data.person).to.eql({
+          id: 4,
+          movies: [
+            {
+              id: 1,
+            },
+            {
+              id: 2,
+            },
+            {
+              id: 3,
+            }
+          ],
+          parent: {
+            id: 1,
+          }
+        });
+      });
+    });
   });
 
 });


### PR DESCRIPTION
This fixes a rather specific bug where a fragment that included multiple relations and was spread after a relation didn't generate a valid eager expression.