### PR TITLE
Custom mutations support

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -83,7 +83,7 @@ class SchemaBuilder {
     return this;
   }
 
-  build() {
+  build(mutationType) {
     _.forOwn(this.models, modelData => {
       modelData.fields = jsonSchemaUtils.jsonSchemaToGraphQLFields(modelData.modelClass.jsonSchema, {
         include: modelData.opt.include,
@@ -95,25 +95,31 @@ class SchemaBuilder {
       modelData.args = this._argsForModel(modelData);
     });
 
-    return new GraphQLSchema({
+    const schemaSetup = {
       query: new GraphQLObjectType({
         name: 'Query',
         fields: () => {
           const fields = {};
 
-          _.forOwn(this.models, (modelData) => {
+         _.forOwn(this.models, (modelData) => {
             const defaultFieldName = fieldNameForModel(modelData.modelClass);
             const singleFieldName = modelData.opt.fieldName || defaultFieldName;
             const listFieldName = modelData.opt.listFieldName || (defaultFieldName + 's');
 
             fields[singleFieldName] = this._rootSingleField(modelData);
             fields[listFieldName] = this._rootListField(modelData);
-          });
+         });
 
-          return fields;
+         return fields;
         }
       })
-    });
+    };
+
+    if (mutationType) {
+      schemaSetup.mutation = mutationType;
+    }
+
+    return new GraphQLSchema(schemaSetup);
   };
 
   _argsForModel(modelData) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "objection-graphql",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Added optional custom _Mutations_ support during the build phase of the _graphql schema_.  Since  Mutations part can be quite opinionated and can heavily depend on a particular domain I would suggest that Mutations implementation should be left to the end user. 