### PR TITLE
Add `extendWithModelMutations` function to builder

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -89,6 +89,25 @@ class SchemaBuilder {
     this.mutation = mutations;
     return this;
   }
+  
+  extendWithModelMutations() {
+    Object.values(this.models).forEach(model => {
+      this._typeForModel(model);
+      model.modelClass.GraphqlTypes = this.typeCache;
+    });
+    let mutations = {};
+    Object.values(this.models).forEach(model => {
+      mutations = Object.assign(mutations, model.modelClass.mutations)
+    });
+    this.extendWithMutations(
+      new GraphQLObjectType({
+        name: 'RootMutationType',
+        description: 'Domain API actions',
+        fields: () => mutations
+      })
+    );
+    return this;
+  }
 
   setBuilderOptions(options) {
     this.builderOptions = options;


### PR DESCRIPTION
Similar to my other pull request, this is just a proof of concept. I'll add tests if we want to move forward. What this enables a user to do is add a `mutations` static object property to their objection model that defines mutations that should be added to the schema. This is currently not compatible with `extendWithMutations`, though it'd be fairly easy to make it so.