### PR TITLE
support virtual properties through dedicated schema

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -152,6 +152,7 @@ class SchemaBuilder {
         exclude: modelData.opt.exclude,
         typeNamePrefix: utils.typeNameForModel(modelData.modelClass),
         typeCache: this.typeCache,
+        virtualJsonSchemaProperties: modelData.modelClass.virtualJsonSchemaProperties
       });
 
       modelData.args = this._argsForModel(modelData);
@@ -459,17 +460,17 @@ class SchemaBuilder {
     if (!this.enableSelectFiltering) {
       return null;
     }
+    const { jsonSchema, virtualJsonSchemaProperties: vProps } = modelClass;
+    const virtualPropertyFilter = (it) => !(vProps && vProps[it])
 
     const relations = modelClass.getRelations();
-    const selects = this._collectSelects(astNode, relations, astRoot.fragments, []);
+    const selects = this._collectSelects(astNode, relations, astRoot.fragments, []).filter(virtualPropertyFilter);
 
     if (selects.length === 0) {
       return null;
     }
 
     return (builder) => {
-      const { jsonSchema } = modelClass;
-
       builder.select(selects.map((it) => {
         const col = modelClass.propertyNameToColumnName(it);
 

--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -6,7 +6,12 @@ const graphqlRoot = require('graphql');
 const jsonSchemaUtils = require('./jsonSchema');
 const defaultArgFactories = require('./argFactories');
 
-const { GraphQLObjectType, GraphQLSchema, GraphQLList } = graphqlRoot;
+const {
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLList,
+  GraphQLInputObjectType
+} = graphqlRoot;
 
 
 // Default arguments that are excluded from the relation arguments.
@@ -68,6 +73,11 @@ class SchemaBuilder {
     return this;
   }
 
+  allModels(models) {
+    models.forEach(model => this.model(model));
+    return this;
+  }
+
   defaultArgNames(defaultArgNameMap) {
     this.defaultArgNameMap = Object.assign({}, this.defaultArgNameMap, defaultArgNameMap);
     return this;
@@ -89,6 +99,35 @@ class SchemaBuilder {
     }
 
     this.mutation = mutations;
+    return this;
+  }
+
+  extendWithModelMutations(options) {
+    if (!options) options = {};
+    if (!options.prefixWithClassName) options.prefixWithClassName = false;
+    Object.values(this.models).forEach(model => {
+      this._typeForModel(model);
+      model.modelClass.GraphqlTypes = this.typeCache;
+    });
+    const mutations = {};
+    Object.values(this.models).forEach(model => {
+      const modelMutations = Object.assign({}, model.modelClass.mutations);
+      if (options.prefixWithClassName) {
+        Object.keys(modelMutations).forEach(mutationName => {
+          modelMutations[`${model.modelClass.name}_${mutationName}`] =
+            modelMutations[mutationName];
+          delete modelMutations[mutationName];
+        });
+      }
+      Object.assign(mutations, modelMutations);
+    });
+    this.extendWithMutations(
+      new GraphQLObjectType({
+        name: "RootMutationType",
+        description: "Domain API actions",
+        fields: () => mutations
+      })
+    );
     return this;
   }
 
@@ -188,6 +227,10 @@ class SchemaBuilder {
       this.typeCache[typeName] = new GraphQLObjectType({
         name: typeName,
         fields: () => Object.assign({}, this._attrFields(modelData), this._relationFields(modelData)),
+      });
+      this.typeCache[typeName + "Input"] = new GraphQLInputObjectType({
+        name: typeName + "Input",
+        fields: () => Object.assign({}, this._attrFields(modelData))
       });
     }
 

--- a/lib/jsonSchema.js
+++ b/lib/jsonSchema.js
@@ -14,11 +14,13 @@ function jsonSchemaToGraphQLFields(jsonSchema, opt) {
     typeIndex: 1,
     typeNamePrefix: '',
     typeCache: {},
+    virtualJsonSchemaProperties: {},
   });
 
   const fields = {};
 
-  _.forOwn(jsonSchema.properties, (propSchema, propName) => {
+  const augmentedJsonSchemaProperties = Object.assign({}, jsonSchema.properties, ctx.virtualJsonSchemaProperties);
+  _.forOwn(augmentedJsonSchemaProperties, (propSchema, propName) => {
     if (utils.isExcluded(ctx, propName)) {
       return;
     }

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -263,6 +263,58 @@ describe('integration tests', () => {
       ]);
     }));
 
+    it('`people` field should have all properties defined in the Person model\'s jsonSchema, plus virtual properties', () => graphql(schema, '{ people { age, birthYear, gender, firstName, lastName, parentId, addresses { street, city, zipCode } } }').then((res) => {
+      const { data: { people } } = res;
+      people.sort(sortByFirstName);
+
+      expect(people).to.eql([
+        {
+          age: 73,
+          birthYear: 1945,
+          firstName: 'Arnold',
+          lastName: 'Schwarzenegger',
+          gender: 'Male',
+          parentId: 1,
+          addresses: [{
+            street: 'Arnoldlane 12',
+            city: 'Arnoldova',
+            zipCode: '123456',
+          }],
+        },
+        {
+          age: 98,
+          birthYear: 1920,
+          firstName: 'Gustav',
+          lastName: 'Schwarzenegger',
+          gender: 'Male',
+          parentId: null,
+          addresses: [{
+            street: 'Gustavroad 64',
+            city: 'Gustavia',
+            zipCode: '654321',
+          }],
+        },
+        {
+          age: 45,
+          birthYear: 1973,
+          firstName: 'Michael',
+          lastName: 'Biehn',
+          gender: 'Male',
+          parentId: null,
+          addresses: null,
+        },
+        {
+          age: 20,
+          birthYear: 1998,
+          firstName: 'Some',
+          lastName: 'Random-Dudette',
+          gender: 'Female',
+          parentId: null,
+          addresses: null,
+        },
+      ]);
+    }));
+
     it('should work with the meta field `__typename`', () => graphql(schema, '{ reviews { title, __typename } }').then((res) => {
       expect(res.data.reviews).to.eql([{
         __typename: 'Review',

--- a/tests/setup/models/Person.js
+++ b/tests/setup/models/Person.js
@@ -14,6 +14,12 @@ class Person extends Model {
     };
   }
 
+  static get virtualJsonSchemaProperties() {
+    return {
+      birthYear: { type: ['number', 'null'] },
+    };
+  }
+
   static get jsonSchema() {
     return {
       type: 'object',
@@ -90,7 +96,11 @@ class Person extends Model {
   }
 
   static get virtualAttributes() {
-    return ['fullName'];
+    return ['fullName', 'birthYear'];
+  }
+
+  birthYear() {
+    return this.age ? (2018 - this.age) : null;
   }
 
   fullName() {


### PR DESCRIPTION
This provides support for virtual properties, even with select filtering on. Not crazy about the API but the types need to be specified somewhere. I considered adding a boolean virtual property to the existing json schema props but I don't think that's compliant with the spec.