### PR TITLE
Virtual attributes

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -118,7 +118,6 @@ class SchemaBuilder {
         exclude: modelData.opt.exclude,
         typeNamePrefix: utils.typeNameForModel(modelData.modelClass),
         typeCache: this.typeCache,
-        virtualJsonSchemaProperties: modelData.modelClass.virtualJsonSchemaProperties
       });
 
       modelData.args = this._argsForModel(modelData);
@@ -422,17 +421,17 @@ class SchemaBuilder {
     if (!this.enableSelectFiltering) {
       return null;
     }
-    const { jsonSchema, virtualJsonSchemaProperties: vProps } = modelClass;
-    const virtualPropertyFilter = (it) => !(vProps && vProps[it])
 
     const relations = modelClass.getRelations();
-    const selects = this._collectSelects(astNode, relations, astRoot.fragments, []).filter(virtualPropertyFilter);
+    const selects = this._collectSelects(astNode, relations, astRoot.fragments, []);
 
     if (selects.length === 0) {
       return null;
     }
 
     return (builder) => {
+      const { jsonSchema } = modelClass;
+
       builder.select(selects.map((it) => {
         const col = modelClass.propertyNameToColumnName(it);
 

--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -422,8 +422,10 @@ class SchemaBuilder {
       return null;
     }
 
+
     const relations = modelClass.getRelations();
-    const selects = this._collectSelects(astNode, relations, astRoot.fragments, []);
+    const { virtualAttributes } = modelClass;
+    const selects = this._collectSelects(astNode, relations, virtualAttributes, astRoot.fragments, []);
 
     if (selects.length === 0) {
       return null;
@@ -443,17 +445,17 @@ class SchemaBuilder {
     };
   }
 
-  _collectSelects(astNode, relations, fragments, selects) {
+  _collectSelects(astNode, relations, virtuals, fragments, selects) {
     for (let i = 0, l = astNode.selectionSet.selections.length; i < l; i += 1) {
       const selectionNode = astNode.selectionSet.selections[i];
 
       if (selectionNode.kind === KIND_FRAGMENT_SPREAD) {
-        this._collectSelects(fragments[selectionNode.name.value], relations, fragments, selects);
+        this._collectSelects(fragments[selectionNode.name.value], relations, virtuals, fragments, selects);
       } else {
         const relation = relations[selectionNode.name.value];
         const isMetaField = GRAPHQL_META_FIELDS.indexOf(selectionNode.name.value) !== -1;
 
-        if (!relation && !isMetaField) {
+        if (!relation && !isMetaField && !_.includes(virtuals, selectionNode.name.value)) {
           selects.push(selectionNode.name.value);
         }
       }

--- a/lib/jsonSchema.js
+++ b/lib/jsonSchema.js
@@ -14,13 +14,11 @@ function jsonSchemaToGraphQLFields(jsonSchema, opt) {
     typeIndex: 1,
     typeNamePrefix: '',
     typeCache: {},
-    virtualJsonSchemaProperties: {},
   });
 
   const fields = {};
 
-  const augmentedJsonSchemaProperties = Object.assign({}, jsonSchema.properties, ctx.virtualJsonSchemaProperties);
-  _.forOwn(augmentedJsonSchemaProperties, (propSchema, propName) => {
+  _.forOwn(jsonSchema.properties, (propSchema, propName) => {
     if (utils.isExcluded(ctx, propName)) {
       return;
     }

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -263,59 +263,6 @@ describe('integration tests', () => {
       ]);
     }));
 
-    it('`people` field should have all properties defined in the Person model\'s jsonSchema, plus virtual properties', () => graphql(schema, '{ people { age, birthYear, gender, firstName, lastName, parentId, addresses { street, city, zipCode } } }').then((res) => {
-      console.log(res);
-      const { data: { people } } = res;
-      people.sort(sortByFirstName);
-
-      expect(people).to.eql([
-        {
-          age: 73,
-          birthYear: 1945,
-          firstName: 'Arnold',
-          lastName: 'Schwarzenegger',
-          gender: 'Male',
-          parentId: 1,
-          addresses: [{
-            street: 'Arnoldlane 12',
-            city: 'Arnoldova',
-            zipCode: '123456',
-          }],
-        },
-        {
-          age: 98,
-          birthYear: 1920,
-          firstName: 'Gustav',
-          lastName: 'Schwarzenegger',
-          gender: 'Male',
-          parentId: null,
-          addresses: [{
-            street: 'Gustavroad 64',
-            city: 'Gustavia',
-            zipCode: '654321',
-          }],
-        },
-        {
-          age: 45,
-          birthYear: 1973,
-          firstName: 'Michael',
-          lastName: 'Biehn',
-          gender: 'Male',
-          parentId: null,
-          addresses: null,
-        },
-        {
-          age: 20,
-          birthYear: 1998,
-          firstName: 'Some',
-          lastName: 'Random-Dudette',
-          gender: 'Female',
-          parentId: null,
-          addresses: null,
-        },
-      ]);
-    }));
-
     it('should work with the meta field `__typename`', () => graphql(schema, '{ reviews { title, __typename } }').then((res) => {
       expect(res.data.reviews).to.eql([{
         __typename: 'Review',

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -263,6 +263,60 @@ describe('integration tests', () => {
       ]);
     }));
 
+
+    it('`people` field should have all properties defined in the Person model\'s jsonSchema, plus virtual properties', () => graphql(schema, '{ people { age, birthYear, gender, firstName, lastName, parentId, addresses { street, city, zipCode } } }').then((res) => {
+      console.log(res);
+      const { data: { people } } = res;
+      people.sort(sortByFirstName);
+
+      expect(people).to.eql([
+        {
+          age: 73,
+          birthYear: 1945,
+          firstName: 'Arnold',
+          lastName: 'Schwarzenegger',
+          gender: 'Male',
+          parentId: 1,
+          addresses: [{
+            street: 'Arnoldlane 12',
+            city: 'Arnoldova',
+            zipCode: '123456',
+          }],
+        },
+        {
+          age: 98,
+          birthYear: 1920,
+          firstName: 'Gustav',
+          lastName: 'Schwarzenegger',
+          gender: 'Male',
+          parentId: null,
+          addresses: [{
+            street: 'Gustavroad 64',
+            city: 'Gustavia',
+            zipCode: '654321',
+          }],
+        },
+        {
+          age: 45,
+          birthYear: 1973,
+          firstName: 'Michael',
+          lastName: 'Biehn',
+          gender: 'Male',
+          parentId: null,
+          addresses: null,
+        },
+        {
+          age: 20,
+          birthYear: 1998,
+          firstName: 'Some',
+          lastName: 'Random-Dudette',
+          gender: 'Female',
+          parentId: null,
+          addresses: null,
+        },
+      ]);
+    }));
+
     it('should work with the meta field `__typename`', () => graphql(schema, '{ reviews { title, __typename } }').then((res) => {
       expect(res.data.reviews).to.eql([{
         __typename: 'Review',

--- a/tests/setup/models/Person.js
+++ b/tests/setup/models/Person.js
@@ -14,12 +14,6 @@ class Person extends Model {
     };
   }
 
-  static get virtualJsonSchemaProperties() {
-    return {
-      birthYear: { type: ['number', 'null'] },
-    };
-  }
-
   static get jsonSchema() {
     return {
       type: 'object',
@@ -96,11 +90,7 @@ class Person extends Model {
   }
 
   static get virtualAttributes() {
-    return ['fullName', 'birthYear'];
-  }
-
-  birthYear() {
-    return this.age ? (2018 - this.age) : null;
+    return ['fullName'];
   }
 
   fullName() {

--- a/tests/setup/models/Person.js
+++ b/tests/setup/models/Person.js
@@ -14,6 +14,12 @@ class Person extends Model {
     };
   }
 
+  static get virtualJsonSchemaProperties() {
+    return {
+      birthYear: { type: ['number', 'null'] },
+    };
+  }
+
   static get jsonSchema() {
     return {
       type: 'object',
@@ -24,6 +30,7 @@ class Person extends Model {
         parentId: { type: ['integer', 'null'] },
         firstName: { type: 'string', minLength: 1, maxLength: 255 },
         lastName: { type: 'string', minLength: 1, maxLength: 255 },
+        birthYear: { type: ['string', 'null'] },
         fullName: { type: 'string' },
         gender: { type: 'string', enum: _.values(Person.Gender) },
         age: { type: ['number', 'null'] },
@@ -90,7 +97,11 @@ class Person extends Model {
   }
 
   static get virtualAttributes() {
-    return ['fullName'];
+    return ['fullName', 'birthYear'];
+  }
+
+  birthYear() {
+    return this.age ? (2018 - this.age) : null;
   }
 
   fullName() {


### PR DESCRIPTION
@nasushkov This is proper support for virtual attributes - requires no additional configuration. It has the user define the attribute directly on the schema and then simply filters it out of selects. This is a lot cleaner than my original implementation. I'm tempted to go ahead and merge it but it removes the old implementation, which would be a breaking change. Personally, I think it's fine - it's only been a day and I don't want the old implementation cluttering up the code base.