### PR TITLE
Get singular and plural model names from jsonSchema

### DIFF
--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -131,8 +131,9 @@ class SchemaBuilder {
 
           _.forOwn(this.models, (modelData) => {
             const defaultFieldName = fieldNameForModel(modelData.modelClass);
-            const singleFieldName = modelData.opt.fieldName || defaultFieldName;
-            const listFieldName = modelData.opt.listFieldName || (`${defaultFieldName}s`);
+            const schema = modelData.modelClass.jsonSchema;
+            const singleFieldName = schema.singleName || modelData.opt.fieldName || defaultFieldName;
+            const listFieldName = schema.collectiveName || modelData.opt.listFieldName || (`${defaultFieldName}s`);
 
             fields[singleFieldName] = this._rootSingleField(modelData);
             fields[listFieldName] = this._rootListField(modelData);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,9 @@ function isExcluded(opt, prop) {
 }
 
 function typeNameForModel(modelClass) {
-  return _.upperFirst(_.camelCase(modelClass.tableName));
+  const schema = modelClass.jsonSchema;
+  const name = schema.singleName || schema.title || modelClass.tableName;
+  return _.upperFirst(_.camelCase(name));
 }
 
 module.exports = {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1281,4 +1281,34 @@ describe('integration tests', () => {
       });
     }));
   });
+
+  describe('get singular and plural names from jsonSchema', () => {
+    let schema;
+
+    before(() => {
+      const { Model } = require('objection');
+      class Human extends Model {
+        static get tableName() { return 'humans' }
+        static get jsonSchema() {
+          return {
+            type: 'object',
+            singleName: 'person',
+            collectiveName: 'mankind',
+            properties: { id: { type: 'integer' }}
+          }
+        }
+      }
+      schema = mainModule
+        .builder()
+        .model(Human)
+        .build();
+    });
+
+    it('has a correct type name', () => {
+      const fields = schema._queryType._fields
+      expect(fields.person.type).to.be.a(GraphQLObjectType);
+      expect(fields.mankind.type).to.be.a(GraphQLList);
+    });
+  });
+
 });


### PR DESCRIPTION
This is similar to `listFieldName` and `fieldName` from `graphQLBuilder().model()`'s extra parameter.
It can simple replace `listFieldName` and `fieldName` if you can add `collectiveName` and `singleName` to your models's jsonSchema.
The benefit is:
* Center the model description;
* Produce the correct single type name in the result graphQL schema;
* Share the model identification with oder modules in the app.