### PR TITLE
Handle json objects without properties as scalars

### DIFF
--- a/lib/jsonSchema.js
+++ b/lib/jsonSchema.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const graphqlRoot = require('graphql');
+const { GraphQLJSONObject } = require('graphql-type-json');
 
 const {
   GraphQLObjectType, GraphQLEnumType, GraphQLBoolean, GraphQLString, GraphQLFloat, GraphQLList, GraphQLInt,
@@ -93,18 +94,23 @@ function objectToGraphQLField(jsonSchema, propName, ctx) {
   const typeName = `${ctx.typeNamePrefix + _.upperFirst(_.camelCase(propName))}JsonType${ctx.typeIndex}`;
 
   if (!ctx.typeIndex[typeName]) {
-    ctx.typeCache[typeName] = new GraphQLObjectType({
-      name: typeName,
-      fields() {
-        const fields = {};
+    if (jsonSchema.properties) {
+      ctx.typeCache[typeName] = new GraphQLObjectType({
+        name: typeName,
+        fields() {
+          const fields = {};
 
-        _.forOwn(jsonSchema.properties, (propSchema, curPropName) => {
-          fields[curPropName] = toGraphQLField(propSchema, curPropName, ctx);
-        });
+          _.forOwn(jsonSchema.properties, (propSchema, curPropName) => {
+            fields[curPropName] = toGraphQLField(propSchema, curPropName, ctx);
+          });
 
-        return fields;
-      },
-    });
+          return fields;
+        },
+      });
+    }
+    else {
+      ctx.typeCache[typeName] = GraphQLJSONObject;
+    }
   }
 
   return { type: ctx.typeCache[typeName] };
@@ -136,6 +142,7 @@ function primitiveToGraphQLType(type) {
     case 'integer': return GraphQLInt;
     case 'number': return GraphQLFloat;
     case 'boolean': return GraphQLBoolean;
+    case 'object': return GraphQLJSONType;
     default: return null;
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "objection": "> 0.8.0"
   },
   "dependencies": {
+    "graphql-type-json": "^0.3.0",
     "lodash": "^4.17.11"
   },
   "devDependencies": {


### PR DESCRIPTION
First off, this could be regarded as an opinionated change, so I understand if it's not accepted for that reason alone. I also haven't included tests for it, which I'm happy to do if it's acceptable.

Objection and JSON schemas in general can handle nested JSON objects. I use these (with `additionalProperties: true`) in my schemas to correspond with `json`/`jsonb` columns in Postgres.

However, GraphQL chokes when provided with a property of type `object` without properties. This proposed change uses the `graphql-type-json` library to handle properties of type `object` as JSON scalar objects when their properties are not defined.

My opinion is that this is inline with how GraphQL would expect such unspecified objects in the schema, but I'm interested in seeing if there are other opinions.