### PR TITLE
Add ability to format lists with paginated results including totalCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,4 +337,49 @@ expressApp.get('/graphql', (req, res, next) => {
 ## setBuilderOptions
 
 Allows you to customize **Objection** query builder behavior. For instance, you can pass `{ skipUndefined: true }` as an options argument. So, each time the builder is called, it will be called with **skipUndefined** enabled. 
-This can be useful when you use [graphql-tools](https://github.com/apollographql/graphql-tools) schema stitching. 
+This can be useful when you use [graphql-tools](https://github.com/apollographql/graphql-tools) schema stitching.
+
+## Pagination
+
+In many cases it is useful to have a total record count to use with pagination.
+If you pass `true` to the `build()` function all list queries will be 
+structured with a `collection` and a `totalCount` field.  For example:
+```js
+const graphQlSchema = graphQlBuilder()
+  .model(Movie)
+  .model(Person)
+  .model(Review)
+  .build(true); // passing in true to get pagination
+``` 
+allows you to do:
+```js
+// Execute a GraphQL query.
+graphql(graphQlSchema, `{
+  movies {
+    collection(nameLike: "%erminato%", range: [0, 2], orderBy: releaseDate) {
+      name,
+      releaseDate,
+      
+      actors(gender: Male, ageLte: 100, orderBy: firstName) {
+        id
+        firstName,
+        age
+      }
+      
+      reviews(starsIn: [3, 4, 5], orderByDesc: stars) {
+        title,
+        text,
+        stars,
+        
+        reviewer {
+          firstName
+        }
+      }
+    },
+  totalCount
+}`).then(result => {
+  console.log(result.data.movies);
+});
+```
+Note the addition of the `collection` and ``totalCount` fields in the 
+GraphQL query.

--- a/README.md
+++ b/README.md
@@ -342,14 +342,15 @@ This can be useful when you use [graphql-tools](https://github.com/apollographql
 ## Pagination
 
 In many cases it is useful to have a total record count to use with pagination.
-If you pass `true` to the `build()` function all list queries will be 
+If you pass `{ paginated: true }` to the `setBuilderOptions` function all list queries will be 
 structured with a `collection` and a `totalCount` field.  For example:
 ```js
 const graphQlSchema = graphQlBuilder()
   .model(Movie)
   .model(Person)
   .model(Review)
-  .build(true); // passing in true to get pagination
+  .setBuilderOptions({ paginated: true })
+  .build(); 
 ``` 
 allows you to do:
 ```js

--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -203,14 +203,14 @@ class SchemaBuilder {
       type: new GraphQLObjectType({
         name: `Paginated${_.upperFirst(listFieldName)}Type`,
         fields: {
-          [listFieldName]: {
+          collection: {
             type: new GraphQLList(this._typeForModel(modelData)),
           },
-          totalCount: { type: GraphQLInt }
-        }
+          totalCount: { type: GraphQLInt },
+        },
       }),
       args: modelData.args,
-      resolve: this._middlewareResolver({ ...modelData, withPagination: true })
+      resolve: this._middlewareResolver(Object.assign({}, modelData, { withPagination: true })),
     };
   }
 
@@ -286,16 +286,17 @@ class SchemaBuilder {
       const { modelClass } = modelData;
       const ast = (data.fieldASTs || data.fieldNodes)[0];
 
-      let clonedAst = { ...ast };
+      const clonedAst = Object.assign({}, ast );
       if (modelData.withPagination) {
         // unroll the AST for the nested collection so that existing query logic works
         const [ innerSelection ] = ast.selectionSet.selections;
         const newSelections = innerSelection.selectionSet.selections;
 
-        clonedAst.selectionSet = {
-          ...ast.selectionSet,
-          selections: newSelections
-        };
+        clonedAst.selectionSet = Object.assign(
+          {},
+          ast.selectionSet,
+          { selections: newSelections }
+        );
       }
       const eager = this._buildEager(clonedAst, modelClass, data);
       const argFilter = this._filterForArgs(clonedAst, modelClass, data.variableValues);
@@ -326,18 +327,21 @@ class SchemaBuilder {
         builder.eager(eager.expression, eager.filters);
       }
 
-      return builder.then(async (res) => {
-        const result =  toJson(res);
+      return builder.then(function (res) {
+        return new Promise(function(resolve) {
+          const result = toJson(res);
 
-        if (modelData.withPagination) {
-          const totalCount = await builder.resultSize();
-          return {
-            [ast.name.value]: result,
-            totalCount
-          };
-        } else {
-          return result;
-        }
+          if (modelData.withPagination) {
+            builder.resultSize().then(function(totalCount) {
+              resolve({
+                collection: result,
+                totalCount
+              });
+            });
+          } else {
+            resolve(result);
+          }
+        })
       });
     };
   }

--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -120,7 +120,7 @@ class SchemaBuilder {
     return this;
   }
 
-  build(withPagination = false) {
+  build() {
     _.forOwn(this.models, (modelData) => {
       modelData.fields = jsonSchemaUtils.jsonSchemaToGraphQLFields(modelData.modelClass.jsonSchema, {
         include: modelData.opt.include,
@@ -144,7 +144,7 @@ class SchemaBuilder {
             const listFieldName = modelData.opt.listFieldName || (`${defaultFieldName}s`);
 
             fields[singleFieldName] = this._rootSingleField(modelData);
-            fields[listFieldName] = withPagination
+            fields[listFieldName] = this.builderOptions && this.builderOptions.paginated
               ? this._rootPaginatedType(modelData)
               : this._rootListField(modelData);
           });

--- a/lib/SchemaBuilder.js
+++ b/lib/SchemaBuilder.js
@@ -6,7 +6,7 @@ const graphqlRoot = require('graphql');
 const jsonSchemaUtils = require('./jsonSchema');
 const defaultArgFactories = require('./argFactories');
 
-const { GraphQLObjectType, GraphQLSchema, GraphQLList } = graphqlRoot;
+const { GraphQLInt, GraphQLObjectType, GraphQLSchema, GraphQLList } = graphqlRoot;
 
 
 // Default arguments that are excluded from the relation arguments.
@@ -120,7 +120,7 @@ class SchemaBuilder {
     return this;
   }
 
-  build() {
+  build(withPagination = false) {
     _.forOwn(this.models, (modelData) => {
       modelData.fields = jsonSchemaUtils.jsonSchemaToGraphQLFields(modelData.modelClass.jsonSchema, {
         include: modelData.opt.include,
@@ -144,7 +144,9 @@ class SchemaBuilder {
             const listFieldName = modelData.opt.listFieldName || (`${defaultFieldName}s`);
 
             fields[singleFieldName] = this._rootSingleField(modelData);
-            fields[listFieldName] = this._rootListField(modelData);
+            fields[listFieldName] = withPagination
+              ? this._rootPaginatedType(modelData)
+              : this._rootListField(modelData);
           });
 
           return fields;
@@ -191,6 +193,24 @@ class SchemaBuilder {
       resolve: this._middlewareResolver(modelData, (query) => {
         query.first();
       }),
+    };
+  }
+
+  _rootPaginatedType(modelData) {
+    const defaultFieldName = fieldNameForModel(modelData.modelClass);
+    const listFieldName = modelData.opt.listFieldName || (`${defaultFieldName}s`);
+    return {
+      type: new GraphQLObjectType({
+        name: `Paginated${_.upperFirst(listFieldName)}Type`,
+        fields: {
+          [listFieldName]: {
+            type: new GraphQLList(this._typeForModel(modelData)),
+          },
+          totalCount: { type: GraphQLInt }
+        }
+      }),
+      args: modelData.args,
+      resolve: this._middlewareResolver({ ...modelData, withPagination: true })
     };
   }
 
@@ -265,9 +285,21 @@ class SchemaBuilder {
 
       const { modelClass } = modelData;
       const ast = (data.fieldASTs || data.fieldNodes)[0];
-      const eager = this._buildEager(ast, modelClass, data);
-      const argFilter = this._filterForArgs(ast, modelClass, data.variableValues);
-      const selectFilter = this._filterForSelects(ast, modelClass, data);
+
+      let clonedAst = { ...ast };
+      if (modelData.withPagination) {
+        // unroll the AST for the nested collection so that existing query logic works
+        const [ innerSelection ] = ast.selectionSet.selections;
+        const newSelections = innerSelection.selectionSet.selections;
+
+        clonedAst.selectionSet = {
+          ...ast.selectionSet,
+          selections: newSelections
+        };
+      }
+      const eager = this._buildEager(clonedAst, modelClass, data);
+      const argFilter = this._filterForArgs(clonedAst, modelClass, data.variableValues);
+      const selectFilter = this._filterForSelects(clonedAst, modelClass, data);
       const builder = modelClass.query(ctx.knex);
 
       if (this.builderOptions && this.builderOptions.skipUndefined) {
@@ -294,7 +326,19 @@ class SchemaBuilder {
         builder.eager(eager.expression, eager.filters);
       }
 
-      return builder.then(toJson);
+      return builder.then(async (res) => {
+        const result =  toJson(res);
+
+        if (modelData.withPagination) {
+          const totalCount = await builder.resultSize();
+          return {
+            [ast.name.value]: result,
+            totalCount
+          };
+        } else {
+          return result;
+        }
+      });
     };
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "objection-graphql",
-  "version": "0.4.2",
+  "version": "0.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -56,6 +56,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2489,7 +2490,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lru-cache": {
       "version": "4.1.1",

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -864,7 +864,8 @@ describe('integration tests', () => {
         .model(session.models.Person, {listFieldName: 'people'})
         .model(session.models.Movie)
         .model(session.models.Review)
-        .build(true);
+        .setBuilderOptions({ paginated: true })
+        .build();
     });
 
     it('root should have `totalCount` field', () => graphql(schema, '{ people { collection { firstName }, totalCount } }').then((res) => {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -265,7 +265,7 @@ describe('integration tests', () => {
 
 
     it('`people` field should have all properties defined in the Person model\'s jsonSchema, plus virtual properties', () => graphql(schema, '{ people { age, birthYear, gender, firstName, lastName, parentId, addresses { street, city, zipCode } } }').then((res) => {
-      console.log(res);
+      // console.log(res);
       const { data: { people } } = res;
       people.sort(sortByFirstName);
 
@@ -855,6 +855,44 @@ describe('integration tests', () => {
     });
   });
 
+  describe('list fields with pagination', () => {
+    let schema;
+
+    beforeEach(() => {
+      schema = mainModule
+        .builder()
+        .model(session.models.Person, {listFieldName: 'people'})
+        .model(session.models.Movie)
+        .model(session.models.Review)
+        .build(true);
+    });
+
+    it('root should have `totalCount` field', () => graphql(schema, '{ people { collection { firstName }, totalCount } }').then((res) => {
+      const { data: { people: { totalCount } } } = res;
+      expect(totalCount).to.eql(4);
+    }));
+
+    it('root should have `people` field', () => graphql(schema, '{ people { collection { firstName } }}').then((res) => {
+      const { data: { people: { collection } } } = res;
+      collection.sort(sortByFirstName);
+
+      expect(collection).to.eql([
+        {
+          firstName: 'Arnold',
+        },
+        {
+          firstName: 'Gustav',
+        },
+        {
+          firstName: 'Michael',
+        },
+        {
+          firstName: 'Some',
+        },
+      ]);
+    }));
+  });
+
   describe('single fields', () => {
     let schema;
 
@@ -1271,7 +1309,7 @@ describe('integration tests', () => {
           if (modelClass.needAuth) { // You can define in model somethig like roles and check it here
             if (!context) { // check your own context property
               throw new Error('Access denied');
-            } 
+            }
           }
           return callback(obj, args, context, info);
         };


### PR DESCRIPTION
In our use of `objection-graphql` we were having a hard time doing pagination correctly.  The main reason is that we did not receive a `totalCount` of records available which made layout of the results difficult.

With this PR, you can build your schema passing `true` into the build function like this:
```
const rootSchema = builder()
  .allModels(allModels);
  .build(true);
```

and once that is constructed, you can query like this:
```
query fetchUsers {
  users(limit: 4, offset: 6) {
    collection {
      id
      name
      handle
      location
      pets {
        name
        type
      }
    }
    totalCount
  } 
}
```
and the `totalCount` is returned along with a list of the users.